### PR TITLE
fix build on mac arm64

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 optimize-arm64 = """docker run --rm -v "$(pwd)":/code \
     --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
     --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-    cosmwasm/rust-optimizer-arm64:0.12.9 \
+    cosmwasm/rust-optimizer-arm64:0.12.8 \
     && mv ./artifacts/stargaze_multisnap-aarch64.wasm ./artifacts/stargaze_multisnap.wasm
 """
 store = """starsd tx wasm store artifacts/stargaze_multisnap.wasm --from testnet-key --gas-prices 0.025ustars --gas-adjustment 1.7 --gas auto --output json -b block -y"""


### PR DESCRIPTION

Version 0.12.9 is not published


```
StargazeMultiSnapshot % cat artifacts/checksums_intermediate.txt
1c0d54a4d3f8bedf8e51cbe61aa0b5a2012608517aa75a6913fc3e3e8329234d  ./target/wasm32-unknown-unknown/release/stargaze_multisnap.wasm
StargazeMultiSnapshot % cat artifacts/checksums.txt 
5f54b01c1b29ee1a0d10ee6a19c764f1532472c6423283243fc16961be4e9047  stargaze_multisnap-aarch64.wasm
StargazeMultiSnapshot % shasum contract.wasm -a 256             
264753975e6de33a120ae59a429a767ecf368d978cb28755b30f675a306e67a4  contract.wasm
```
